### PR TITLE
Fix get inventories to include warehouse_name in response

### DIFF
--- a/controllers/inventoriesControler.js
+++ b/controllers/inventoriesControler.js
@@ -7,7 +7,17 @@ const knex = require("knex")(require("../knexfile"));
  */
 const getInventoriesList = async (_req, res) => {
   try {
-    const data = await knex("inventories");
+    const data = await knex('inventories')
+    .join('warehouses', 'inventories.warehouse_id', '=', 'warehouses.id')
+    .select(
+      'inventories.id as id',
+      'warehouses.warehouse_name as warehouse_name',
+      'inventories.item_name as item_name',
+      'inventories.description as description',
+      'inventories.category as category',
+      'inventories.status as status',
+      'inventories.quantity as quantity',
+    );
     res.status(200).json(data);
   } catch (err) {
     res.status(500).json({
@@ -23,7 +33,18 @@ const getInventoriesList = async (_req, res) => {
  */
 const getSingleInventory = async (req, res) => {
   try {
-    const inventory = await knex("inventories").where({ id: req.params.id });
+    const inventory = await knex('inventories')
+    .where({ 'inventories.id': req.params.id })
+    .join('warehouses', 'inventories.warehouse_id', '=', 'warehouses.id')
+    .select(
+      'inventories.id as id',
+      'warehouses.warehouse_name as warehouse_name',
+      'inventories.item_name as item_name',
+      'inventories.description as description',
+      'inventories.category as category',
+      'inventories.status as status',
+      'inventories.quantity as quantity',
+    );;
     if (inventory[0]) {
       res.status(200).json(inventory[0]);
     } else {


### PR DESCRIPTION
For /api/inventories/, it will return following. The response should include `warehouse_name`.
```
[
  {
    "id": 1,
    "warehouse_name": "Manhattan",
    "item_name": "Television",
    "description": "This 50\", 4K LED TV provides a crystal-clear picture and vivid colors.",
    "category": "Electronics",
    "status": "In Stock",
    "quantity": 500
  },
  {
    "id": 2,
    "warehouse_name": "Manhattan",
    "item_name": "Gym Bag",
    "description": "Made out of military-grade synthetic materials, this gym bag is highly durable, water resistant, and easy to clean.",
    "category": "Gear",
    "status": "Out of Stock",
    "quantity": 0
  },
]
```

For /api/inventories/:id, it will return following. The response should include `warehouse_name`.
```
{
  "id": 2,
  "warehouse_name": "Manhattan",
  "item_name": "Gym Bag",
  "description": "Made out of military-grade synthetic materials, this gym bag is highly durable, water resistant, and easy to clean.",
  "category": "Gear",
  "status": "Out of Stock",
  "quantity": 0
}
```